### PR TITLE
Get from disk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["William Speirs <bill.speirs@gmail.com>"]
 
 [dependencies]
-rand = "*"
+rand = "0.5.0"
 bincode = "0.6.0"
 rustc-serialize = "0.3.19"
 itertools = "0.5.5"

--- a/src/wal_file.rs
+++ b/src/wal_file.rs
@@ -165,4 +165,40 @@ mod tests {
 
         fs::remove_file(&file_path);
     }
+
+    #[test]
+    fn load_from_disk() {
+        let temp_path = gen_temp_name();
+        let file_path = temp_path.to_owned() + ".wal";
+
+        // create a new blank file
+        let mut wal_file = RecordFile::new(&file_path, 20, 20).unwrap();
+        assert!(wal_file.is_new().unwrap());
+
+        let kv1 = KeyValuePair{key: "hello".to_owned(), value: "world".to_owned()};
+        let kv2 = KeyValuePair{key: "foo".to_owned(), value: "bar".to_owned()};
+
+        wal_file.insert_record(&kv1).unwrap();
+        wal_file.insert_record(&kv2).unwrap();
+
+        // drop the above wal_file and create a new one
+        drop(wal_file);
+        let mut wal_file : RecordFile<String, String> = RecordFile::new(&file_path, 20, 20).unwrap();
+
+        assert!(wal_file.count().unwrap() == 2);
+
+        let mut wal_it = wal_file.into_iter();
+
+        let it_kv1 = wal_it.next().unwrap();
+
+        assert!(kv1.key == it_kv1.key);
+        assert!(kv1.value == it_kv1.value);
+
+        let it_kv2 = wal_it.next().unwrap();
+
+        assert!(kv2.key == it_kv2.key);
+        assert!(kv2.value == it_kv2.value);
+
+        fs::remove_file(&file_path);
+    }
 }


### PR DESCRIPTION
closes #3 

This adds tests and fixes a bug when initializing btree from disk. In order to get this to compile, I also had to change the version of the `rand` dependency from "*" to "0.5.0". 